### PR TITLE
Fix duplicate contributor comment not being posted

### DIFF
--- a/.github/workflows/process-contribution.yml
+++ b/.github/workflows/process-contribution.yml
@@ -133,8 +133,7 @@ jobs:
       - name: Comprehensive validation and profanity check
         id: validate
         if: steps.file-check.outputs.valid == 'true'
-        continue-on-error: true
-        run: node scripts/comprehensive-validation.js
+        run: node scripts/comprehensive-validation.js || true
 
       - name: Verify GitHub username matches PR author
         if: steps.file-check.outputs.valid == 'true' && steps.validate.outputs.valid == 'true' && steps.validate.outputs.profanity_detected != 'true'


### PR DESCRIPTION
## Problem
When a user tries to contribute twice (duplicate contributor), the validation script exits with code 1 after calling setError(). Even though continue-on-error: true was set, the outputs weren't being captured properly, so the duplicate comment was never posted to the PR.

## Solution
Changed from \ to using \ at the end of the command. This ensures:
- The step always succeeds
- Outputs are properly set before the step completes
- The duplicate detection comment logic can read the outputs and post the comment

## Test Case
This would have fixed PR #79 where @AshaSaini-033 tried to contribute twice but got no comment explaining they were already a contributor.