### PR TITLE
Fix case-sensitive username validation

### DIFF
--- a/.github/workflows/process-contribution.yml
+++ b/.github/workflows/process-contribution.yml
@@ -141,7 +141,11 @@ jobs:
         run: |
           ENTRY_USERNAME="${{ steps.validate.outputs.username }}"
 
-          if [ "$PR_AUTHOR" != "$ENTRY_USERNAME" ]; then
+          # Case-insensitive comparison (GitHub usernames are case-insensitive)
+          PR_AUTHOR_LOWER=$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')
+          ENTRY_USERNAME_LOWER=$(echo "$ENTRY_USERNAME" | tr '[:upper:]' '[:lower:]')
+
+          if [ "$PR_AUTHOR_LOWER" != "$ENTRY_USERNAME_LOWER" ]; then
             echo "valid=false" >> $GITHUB_OUTPUT
             echo "error=Username mismatch: Your GitHub username is @$PR_AUTHOR but you entered @$ENTRY_USERNAME. Please use your own GitHub username." >> $GITHUB_OUTPUT
             echo "Username validation failed"


### PR DESCRIPTION
GitHub usernames are case-insensitive. Users should be able to enter their username in any case.

Example: User 'KhotSaprem' entering 'khotsaprem' should be accepted.

Changes username comparison from case-sensitive to case-insensitive using tr command.

Fixes issue seen in PR #110 where valid username was rejected due to case mismatch.