### PR TITLE
Make approval comment fail gracefully

### DIFF
--- a/.github/workflows/process-contribution.yml
+++ b/.github/workflows/process-contribution.yml
@@ -195,7 +195,8 @@ jobs:
           # Replace placeholders
           sed -i "s|ENTRY_PLACEHOLDER|${{ steps.validate.outputs.entry }}|g" /tmp/approval-comment.md
 
-          gh pr comment $PR_NUMBER --body-file /tmp/approval-comment.md
+          # Try to comment (may fail if already exists or rate limited)
+          gh pr comment $PR_NUMBER --body-file /tmp/approval-comment.md || echo "Comment skipped"
 
           # Remove invalid/moderation labels if they exist (user fixed their entry or maintainer approved)
           gh pr edit $PR_NUMBER --remove-label "invalid" 2>/dev/null || true


### PR DESCRIPTION
Prevents workflow failure when comment cannot be posted (e.g., rate limits or duplicate).

Allows workflow to continue with auto-merge even if comment fails.