### PR TITLE
Change heading to 'Add Your Name' and add strict validation

### DIFF
--- a/ADD_YOUR_NAME.md
+++ b/ADD_YOUR_NAME.md
@@ -1,4 +1,4 @@
-# Add Your Name Here
+# Add Your Name
 
 Want to join the Git Gang? Just fill out the form below.
 

--- a/scripts/comprehensive-validation.js
+++ b/scripts/comprehensive-validation.js
@@ -23,12 +23,17 @@ async function validateContribution() {
     const content = fs.readFileSync('ADD_YOUR_NAME.md', 'utf8');
     const lines = content.split('\n');
 
-    // Check if file has required template structure
-    const hasTitle = content.includes('# Add Your Name Here');
+    // Check if file has required template structure with exact heading match
+    const firstLine = lines[0].trim();
+    if (firstLine !== '# Add Your Name') {
+      setError('The first line must be exactly "# Add Your Name". Do not modify the template heading.');
+      return false;
+    }
+
     const hasInstructions = content.includes('Want to join the Git Gang?');
     const hasSectionMarker = content.includes('Add your entry below this line');
 
-    if (!hasTitle || !hasInstructions || !hasSectionMarker) {
+    if (!hasInstructions || !hasSectionMarker) {
       setError('ADD_YOUR_NAME.md template structure is missing. Please keep the original template and only fill in your details below "Add your entry below this line".');
       return false;
     }

--- a/scripts/reset-staging.js
+++ b/scripts/reset-staging.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 
 function resetStagingFile() {
   try {
-    const template = `# Add Your Name Here
+    const template = `# Add Your Name
 
 Want to join the Git Gang? Just fill out the form below.
 

--- a/scripts/validate-contribution.js
+++ b/scripts/validate-contribution.js
@@ -22,12 +22,17 @@ function main() {
     const content = fs.readFileSync('ADD_YOUR_NAME.md', 'utf8');
     const lines = content.split('\n');
 
-    // Check if file has required template structure
-    const hasTitle = content.includes('# Add Your Name Here');
+    // Check if file has required template structure with exact heading match
+    const firstLine = lines[0].trim();
+    if (firstLine !== '# Add Your Name') {
+      setError('The first line must be exactly "# Add Your Name". Do not modify the template heading.');
+      return;
+    }
+
     const hasInstructions = content.includes('Want to join the Git Gang?');
     const hasSectionMarker = content.includes('Add your entry below this line');
 
-    if (!hasTitle || !hasInstructions || !hasSectionMarker) {
+    if (!hasInstructions || !hasSectionMarker) {
       setError('ADD_YOUR_NAME.md template structure is missing. Please keep the original template and only fill in your details below "Add your entry below this line".');
       return;
     }


### PR DESCRIPTION
Removes 'Here' from template heading to prevent user confusion and adds strict validation.

## Changes
- Heading changed from '# Add Your Name Here' to '# Add Your Name' (less misleading)
- Strict first-line validation prevents heading modifications
- Prevents users from deleting entire template

## Prevents Issues Like
- https://github.com/SashankBhamidi/git-gang/pull/126/commits/2bd9a5c (user changed heading to their name)
- https://github.com/SashankBhamidi/git-gang/pull/137/commits/6e48e8b (user deleted entire template)

Tested with valid entries, modified headings, deleted templates, and edge cases.



