### PR TITLE
Strip GitHub URLs from username field

### DIFF
--- a/scripts/validation-utils.js
+++ b/scripts/validation-utils.js
@@ -65,9 +65,18 @@ function parseSimpleFormat(text) {
     return null;
   }
 
+  // Extract username from various formats
+  let username = usernameMatch[1].trim();
+  // Strip @ prefix
+  username = username.replace(/^@/, '');
+  // Strip GitHub URL (https://github.com/username or github.com/username)
+  username = username.replace(/^(?:https?:\/\/)?(?:www\.)?github\.com\//, '');
+  // Remove trailing slashes
+  username = username.replace(/\/$/, '');
+
   return {
     name: capitalizeWords(nameMatch[1].trim()),
-    username: usernameMatch[1].trim().replace(/^@/, ''),
+    username: username,
     message: messageMatch ? messageMatch[1].trim() : ''
   };
 }


### PR DESCRIPTION
Handles users entering full GitHub URLs instead of just username.

Strips: @, https://github.com/, github.com/, trailing slashes

Fixes #173