### PR TITLE
Detect and reject file rename attempts

### DIFF
--- a/.github/workflows/process-contribution.yml
+++ b/.github/workflows/process-contribution.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Check only ADD_YOUR_NAME.md is modified
         id: file-check
         run: |
+          # Check if ADD_YOUR_NAME.md was renamed
+          if git diff --name-status origin/master...${{ github.event.pull_request.head.sha || github.sha }} | grep -q "^R.*ADD_YOUR_NAME.md"; then
+            echo "valid=false" >> $GITHUB_OUTPUT
+            echo "is_contribution=false" >> $GITHUB_OUTPUT
+            echo "error_message=DO NOT rename ADD_YOUR_NAME.md! Edit the file directly, don't rename it to your name." >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           files_changed=$(git diff --name-only origin/master...${{ github.event.pull_request.head.sha || github.sha }})
           file_count=$(echo "$files_changed" | wc -l)
           files_list=$(echo "$files_changed" | tr '\n' ', ' | sed 's/,/, /g' | sed 's/, $//')


### PR DESCRIPTION
Catches when users rename ADD_YOUR_NAME.md to their name instead of editing it.

Provides clearer error: 'DO NOT rename ADD_YOUR_NAME.md! Edit the file directly, don't rename it to your name.'

Fixes PR #298 type issues.